### PR TITLE
Updated the composer.json to support symfony 7.0 and still support 6.4 .

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,21 +14,21 @@
     },
     "require": {
         "php": "^8.2",
-        "symfony/config": "^6.4",
-        "symfony/console": "^6.4",
-        "symfony/dependency-injection": "^6.4",
-        "symfony/http-foundation": "^6.4",
-        "symfony/http-kernel": "^6.4",
-        "symfony/yaml": "^6.4"
+        "symfony/config": "^6.4|^7.0",
+        "symfony/console": "^6.4|^7.0",
+        "symfony/dependency-injection": "^6.4|^7.0",
+        "symfony/http-foundation": "^6.4|^7.0",
+        "symfony/http-kernel": "^6.4|^7.0",
+        "symfony/yaml": "^6.4|^7.0"
     },
     "require-dev": {
         "phpstan/phpstan": "^1.10",
         "phpstan/phpstan-symfony": "^1.3",
         "phpstan/phpstan-phpunit": "^1.3",
         "phpunit/phpunit": "^10.3",
-        "symfony/browser-kit": "^6.4",
-        "symfony/framework-bundle": "^6.4",
-        "symfony/var-dumper": "^6.4"
+        "symfony/browser-kit": "^6.4|^7.0",
+        "symfony/framework-bundle": "^6.4|^7.0",
+        "symfony/var-dumper": "^6.4|^7.0"
     },
     "scripts": {
         "test": "vendor/bin/phpunit",


### PR DESCRIPTION
This addition adds a OR support for 7.0 of the symfony framework. 

For example; 

`symfony/config:^6.4` causes an error on `composer require` if the project has a lock of `symfony/config:^7.0` so the package can't be required into any projects that are currently set up to use `7.0`. 

This change adds it as a supported option so it can be installed by those projects. 