### PR TITLE
Added Required to the Schema for rendering.

### DIFF
--- a/src/Attribute/AbstractProperty.php
+++ b/src/Attribute/AbstractProperty.php
@@ -9,6 +9,7 @@ abstract class AbstractProperty
     public function __construct(
         public string $name,
         public string $description,
+        public bool $required,
     ) {
     }
 
@@ -17,6 +18,7 @@ abstract class AbstractProperty
         return [
             'name' => $this->name,
             'description' => $this->description,
+            'required' => $this->required,
         ];
     }
 }

--- a/src/Attribute/Property.php
+++ b/src/Attribute/Property.php
@@ -17,9 +17,9 @@ class Property extends AbstractProperty implements PropertyInterface
         public readonly PropertyType $type = PropertyType::STRING,
         public readonly ?Format $format = null,
         public readonly ?string $example = null,
-        public readonly bool $required = true,
+        bool $required = true,
     ) {
-        parent::__construct($name, $description);
+        parent::__construct($name, $description, $required);
     }
 
     public function toArray(): array

--- a/src/Attribute/PropertyArray.php
+++ b/src/Attribute/PropertyArray.php
@@ -17,9 +17,9 @@ class PropertyArray extends AbstractProperty implements PropertyInterface
         string $description = '',
         public readonly ?Format $format = null,
         public readonly ?string $example = null,
-        public readonly bool $required = true,
+        bool $required = true,
     ) {
-        parent::__construct($name, $description);
+        parent::__construct($name, $description, $required);
     }
 
     public function toArray(): array

--- a/src/Attribute/PropertyArrayObject.php
+++ b/src/Attribute/PropertyArrayObject.php
@@ -16,9 +16,9 @@ class PropertyArrayObject extends AbstractProperty implements PropertyInterface
         string $description = '',
         public ?Format $format = null,
         public ?string $example = null,
-        public bool $required = true,
+        bool $required = true,
     ) {
-        parent::__construct($name, $description);
+        parent::__construct($name, $description, $required);
     }
 
     public function toArray(): array

--- a/src/Attribute/PropertyEnum.php
+++ b/src/Attribute/PropertyEnum.php
@@ -20,9 +20,9 @@ class PropertyEnum extends AbstractProperty implements PropertyInterface
         string $description = '',
         public ?Format $format = null,
         public ?string $example = null,
-        public bool $required = true,
+        bool $required = true,
     ) {
-        parent::__construct($name, $description);
+        parent::__construct($name, $description, $required);
     }
 
     public function toArray(): array

--- a/src/Attribute/PropertyObject.php
+++ b/src/Attribute/PropertyObject.php
@@ -14,9 +14,9 @@ class PropertyObject extends AbstractProperty implements PropertyInterface
         public readonly string $class,
         string $description = '',
         public readonly array $items = [],
-        public readonly bool $required = true,
+        bool $required = true,
     ) {
-        parent::__construct($name, $description);
+        parent::__construct($name, $description, $required);
     }
 
     public function toArray(): array

--- a/src/Generator/JsonGenerator.php
+++ b/src/Generator/JsonGenerator.php
@@ -20,6 +20,6 @@ final readonly class JsonGenerator implements GeneratorInterface
      */
     public function generate(): string
     {
-        return json_encode($this->generator->generate(), JSON_THROW_ON_ERROR | JSON_FORCE_OBJECT);
+        return json_encode($this->generator->generate(), JSON_THROW_ON_ERROR);
     }
 }

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -24,6 +24,10 @@ class Schema
             if (isset($property['example'])) {
                 $properties[$property['name']]['example'] = $property['example'];
             }
+
+            if (isset($property['required'])) {
+                $properties[$property['name']]['required'] = $property['required'];
+            }
         }
 
         $message[$document['name']] = [

--- a/src/Schema.php
+++ b/src/Schema.php
@@ -9,6 +9,7 @@ class Schema
     public function render(array $document): array
     {
         $properties = [];
+        $required = [];
 
         foreach ($document['properties'] as $property) {
             $properties[$property['name']]['type'] = PropertyTypeTranslator::translate($property['type']);
@@ -26,7 +27,7 @@ class Schema
             }
 
             if (isset($property['required'])) {
-                $properties[$property['name']]['required'] = $property['required'];
+                $required[] = $property['name'];
             }
         }
 
@@ -34,6 +35,7 @@ class Schema
             'payload' => [
                 'type' => 'object',
                 'properties' => $properties,
+                'required' => $required,
             ],
         ];
 

--- a/tests/Integration/DumpSpecificationConsoleTest.php
+++ b/tests/Integration/DumpSpecificationConsoleTest.php
@@ -35,25 +35,26 @@ UserSignedUp:
         description: 'Name of the user'
         format: string
         example: John
-        required: true
       email:
         type: string
         description: 'Email of the user'
         format: email
         example: john@example.com
-        required: true
       age:
         type: integer
         description: 'Age of the user'
         format: int32
         example: '18'
-        required: true
       isCitizen:
         type: boolean
         description: 'Is user a citizen'
         format: boolean
         example: 'true'
-        required: true
+    required:
+      - name
+      - email
+      - age
+      - isCitizen
 
 
 YAML;
@@ -113,25 +114,26 @@ components:
             description: 'Name of the user'
             format: string
             example: John
-            required: true
           email:
             type: string
             description: 'Email of the user'
             format: email
             example: john@example.com
-            required: true
           age:
             type: integer
             description: 'Age of the user'
             format: int32
             example: '18'
-            required: true
           isCitizen:
             type: boolean
             description: 'Is user a citizen'
             format: boolean
             example: 'true'
-            required: true
+        required:
+          - name
+          - email
+          - age
+          - isCitizen
     PaymentExecuted:
       payload:
         type: object
@@ -141,13 +143,14 @@ components:
             description: 'Payment amount'
             format: float
             example: '1000'
-            required: true
           createdAt:
             type: string
             description: 'Creation date'
             format: date-time
             example: '2023-11-23 13:41:21'
-            required: true
+        required:
+          - amount
+          - createdAt
     ProductCreated:
       payload:
         type: object
@@ -155,40 +158,41 @@ components:
           id:
             type: integer
             description: ''
-            required: true
           amount:
             type: number
             description: ''
-            required: true
           currency:
             type: string
             description: ''
-            required: true
           isPaid:
             type: boolean
             description: ''
-            required: true
           createdAt:
             type: string
             description: ''
             format: date-time
-            required: true
           week:
             type: integer
             description: ''
-            required: true
           payment:
             type: string
             description: ''
-            required: true
           products:
             type: string
             description: ''
-            required: true
           tags:
             type: string
             description: ''
-            required: true
+        required:
+          - id
+          - amount
+          - currency
+          - isPaid
+          - createdAt
+          - week
+          - payment
+          - products
+          - tags
 
 
 YAML;
@@ -268,31 +272,33 @@ YAML;
               "type": "string",
               "description": "Name of the user",
               "format": "string",
-              "example": "John",
-              "required": true
+              "example": "John"
             },
             "email": {
               "type": "string",
               "description": "Email of the user",
               "format": "email",
-              "example": "john@example.com",
-              "required": true
+              "example": "john@example.com"
             },
             "age": {
               "type": "integer",
               "description": "Age of the user",
               "format": "int32",
-              "example": "18",
-              "required": true
+              "example": "18"
             },
             "isCitizen": {
               "type": "boolean",
               "description": "Is user a citizen",
               "format": "boolean",
-              "example": "true",
-              "required": true
+              "example": "true"
             }
-          }
+          },
+            "required": [
+                "name",
+                "email",
+                "age",
+                "isCitizen"
+            ]
         }
       },
       "PaymentExecuted": {
@@ -303,17 +309,19 @@ YAML;
               "type": "number",
               "description": "Payment amount",
               "format": "float",
-              "example": "1000",
-              "required": true
+              "example": "1000"
             },
             "createdAt": {
               "type": "string",
               "description": "Creation date",
               "format": "date-time",
-              "example": "2023-11-23 13:41:21",
-              "required": true
+              "example": "2023-11-23 13:41:21"
             }
-          }
+          },
+            "required": [
+                "amount",
+                "createdAt"
+            ]
         }
       },
       "ProductCreated": {
@@ -322,51 +330,53 @@ YAML;
           "properties": {
             "id": {
               "type": "integer",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "amount": {
               "type": "number",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "currency": {
               "type": "string",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "isPaid": {
               "type": "boolean",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "createdAt": {
               "type": "string",
               "description": "",
-              "format": "date-time",
-              "required": true
+              "format": "date-time"
             },
             "week": {
               "type": "integer",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "payment": {
               "type": "string",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "products": {
               "type": "string",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "tags": {
               "type": "string",
-              "description": "",
-              "required": true
+              "description": ""
             }
-          }
+          },
+            "required": [
+                "id",
+                "amount",
+                "currency",
+                "isPaid",
+                "createdAt",
+                "week",
+                "payment",
+                "products",
+                "tags"
+            ]
         }
       }
     }

--- a/tests/Integration/DumpSpecificationConsoleTest.php
+++ b/tests/Integration/DumpSpecificationConsoleTest.php
@@ -35,21 +35,25 @@ UserSignedUp:
         description: 'Name of the user'
         format: string
         example: John
+        required: true
       email:
         type: string
         description: 'Email of the user'
         format: email
         example: john@example.com
+        required: true
       age:
         type: integer
         description: 'Age of the user'
         format: int32
         example: '18'
+        required: true
       isCitizen:
         type: boolean
         description: 'Is user a citizen'
         format: boolean
         example: 'true'
+        required: true
 
 
 YAML;
@@ -109,21 +113,25 @@ components:
             description: 'Name of the user'
             format: string
             example: John
+            required: true
           email:
             type: string
             description: 'Email of the user'
             format: email
             example: john@example.com
+            required: true
           age:
             type: integer
             description: 'Age of the user'
             format: int32
             example: '18'
+            required: true
           isCitizen:
             type: boolean
             description: 'Is user a citizen'
             format: boolean
             example: 'true'
+            required: true
     PaymentExecuted:
       payload:
         type: object
@@ -133,11 +141,13 @@ components:
             description: 'Payment amount'
             format: float
             example: '1000'
+            required: true
           createdAt:
             type: string
             description: 'Creation date'
             format: date-time
             example: '2023-11-23 13:41:21'
+            required: true
     ProductCreated:
       payload:
         type: object
@@ -145,31 +155,40 @@ components:
           id:
             type: integer
             description: ''
+            required: true
           amount:
             type: number
             description: ''
+            required: true
           currency:
             type: string
             description: ''
+            required: true
           isPaid:
             type: boolean
             description: ''
+            required: true
           createdAt:
             type: string
             description: ''
             format: date-time
+            required: true
           week:
             type: integer
             description: ''
+            required: true
           payment:
             type: string
             description: ''
+            required: true
           products:
             type: string
             description: ''
+            required: true
           tags:
             type: string
             description: ''
+            required: true
 
 
 YAML;
@@ -249,25 +268,29 @@ YAML;
               "type": "string",
               "description": "Name of the user",
               "format": "string",
-              "example": "John"
+              "example": "John",
+              "required": true
             },
             "email": {
               "type": "string",
               "description": "Email of the user",
               "format": "email",
-              "example": "john@example.com"
+              "example": "john@example.com",
+              "required": true
             },
             "age": {
               "type": "integer",
               "description": "Age of the user",
               "format": "int32",
-              "example": "18"
+              "example": "18",
+              "required": true
             },
             "isCitizen": {
               "type": "boolean",
               "description": "Is user a citizen",
               "format": "boolean",
-              "example": "true"
+              "example": "true",
+              "required": true
             }
           }
         }
@@ -280,13 +303,15 @@ YAML;
               "type": "number",
               "description": "Payment amount",
               "format": "float",
-              "example": "1000"
+              "example": "1000",
+              "required": true
             },
             "createdAt": {
               "type": "string",
               "description": "Creation date",
               "format": "date-time",
-              "example": "2023-11-23 13:41:21"
+              "example": "2023-11-23 13:41:21",
+              "required": true
             }
           }
         }
@@ -297,40 +322,49 @@ YAML;
           "properties": {
             "id": {
               "type": "integer",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "amount": {
               "type": "number",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "currency": {
               "type": "string",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "isPaid": {
               "type": "boolean",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "createdAt": {
               "type": "string",
               "description": "",
-              "format": "date-time"
+              "format": "date-time",
+              "required": true
             },
             "week": {
               "type": "integer",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "payment": {
               "type": "string",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "products": {
               "type": "string",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "tags": {
               "type": "string",
-              "description": ""
+              "description": "",
+              "required": true
             }
           }
         }

--- a/tests/Unit/Attribute/PropertyArrayObjectTest.php
+++ b/tests/Unit/Attribute/PropertyArrayObjectTest.php
@@ -20,6 +20,7 @@ class PropertyArrayObjectTest extends TestCase
             'type' => 'array',
             'format' => null,
             'example' => null,
+            'required' => true,
         ];
 
         $actual = $property->toArray();

--- a/tests/Unit/Attribute/PropertyArrayTest.php
+++ b/tests/Unit/Attribute/PropertyArrayTest.php
@@ -24,6 +24,7 @@ class PropertyArrayTest extends TestCase
             'itemsType' => 'string',
             'format' => null,
             'example' => null,
+            'required' => true,
         ];
 
         $actual = $property->toArray();

--- a/tests/Unit/Attribute/PropertyEnumTest.php
+++ b/tests/Unit/Attribute/PropertyEnumTest.php
@@ -23,6 +23,7 @@ class PropertyEnumTest extends TestCase
             'enum' => [1, 2, 3, 4, 5, 6, 7],
             'format' => null,
             'example' => null,
+            'required' => true,
         ];
 
         $actual = $property->toArray();

--- a/tests/Unit/Attribute/PropertyObjectTest.php
+++ b/tests/Unit/Attribute/PropertyObjectTest.php
@@ -21,6 +21,7 @@ class PropertyObjectTest extends TestCase
             'description' => '',
             'type' => 'object',
             'items' => [],
+            'required' => true,
         ];
 
         $actual = $property->toArray();
@@ -47,8 +48,10 @@ class PropertyObjectTest extends TestCase
                     'type' => 'string',
                     'format' => null,
                     'example' => null,
+                    'required' => true,
                 ]
             ],
+            'required' => true,
         ];
 
         $actual = $property->toArray();

--- a/tests/Unit/Attribute/PropertyTest.php
+++ b/tests/Unit/Attribute/PropertyTest.php
@@ -24,6 +24,7 @@ class PropertyTest extends TestCase
             'type' => 'string',
             'format' => null,
             'example' => null,
+            'required' => true,
         ];
 
         $actual = $property->toArray();

--- a/tests/Unit/DocumentationStrategy/AttributeDocumentationStrategyTest.php
+++ b/tests/Unit/DocumentationStrategy/AttributeDocumentationStrategyTest.php
@@ -27,6 +27,7 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'description' => 'Name of the user',
                     'example' => 'John',
                     'format' => 'string',
+                    'required' => true,
                 ],
                 [
                     'name' => 'email',
@@ -34,6 +35,7 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'description' => 'Email of the user',
                     'format' => 'email',
                     'example' => 'john@example.com',
+                    'required' => true,
                 ],
                 [
                     'name' => 'age',
@@ -41,6 +43,7 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'description' => 'Age of the user',
                     'format' => 'int32',
                     'example' => '18',
+                    'required' => true,
                 ],
                 [
                     'name' => 'isCitizen',
@@ -48,6 +51,7 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'description' => 'Is user a citizen',
                     'format' => 'boolean',
                     'example' => 'true',
+                    'required' => true,
                 ],
             ],
         ];
@@ -70,6 +74,7 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'type' => 'integer',
                     'format' => null,
                     'example' => null,
+                    'required' => true,
                 ],
                 [
                     'name' => 'amount',
@@ -77,6 +82,7 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'type' => 'number',
                     'format' => null,
                     'example' => null,
+                    'required' => true,
                 ],
                 [
                     'name' => 'currency',
@@ -84,6 +90,7 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'type' => 'string',
                     'format' => null,
                     'example' => null,
+                    'required' => true,
                 ],
                 [
                     'name' => 'isPaid',
@@ -91,6 +98,7 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'type' => 'boolean',
                     'format' => null,
                     'example' => null,
+                    'required' => true,
                 ],
                 [
                     'name' => 'createdAt',
@@ -98,6 +106,7 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'type' => 'string',
                     'format' => 'date-time',
                     'example' => null,
+                    'required' => true,
                 ],
                 [
                     'name' => 'week',
@@ -106,12 +115,14 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'enum' => [1, 2, 3, 4, 5, 6, 7],
                     'format' => null,
                     'example' => null,
+                    'required' => true,
                 ],
                 [
                     'name' => 'payment',
                     'description' => '',
                     'type' => 'object',
                     'items' => [],
+                    'required' => true,
                 ],
                 [
                     'name' => 'products',
@@ -119,6 +130,7 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'type' => 'array',
                     'format' => null,
                     'example' => null,
+                    'required' => true,
                 ],
                 [
                     'name' => 'tags',
@@ -127,6 +139,7 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'format' => null,
                     'example' => null,
                     'itemsType' => 'string',
+                    'required' => true,
                 ],
             ],
         ];

--- a/tests/Unit/SchemaTest.php
+++ b/tests/Unit/SchemaTest.php
@@ -18,18 +18,22 @@ class SchemaTest extends TestCase
                 [
                     'name' => 'name',
                     'type' => 'string',
+                    'required' => true,
                 ],
                 [
                     'name' => 'email',
                     'type' => 'string',
+                    'required' => true,
                 ],
                 [
                     'name' => 'age',
                     'type' => 'int',
+                    'required' => true,
                 ],
                 [
                     'name' => 'isCitizen',
                     'type' => 'bool',
+                    'required' => true,
                 ],
             ],
         ];
@@ -51,6 +55,11 @@ UserSignedUp:
         type: integer
       isCitizen:
         type: boolean
+    required:
+      - name
+      - email
+      - age
+      - isCitizen
 
 YAML;
 
@@ -68,6 +77,7 @@ YAML;
                     'description' => 'Name of the user',
                     'example' => 'John',
                     'format' => 'string',
+                    'required' => true,
                 ],
                 [
                     'name' => 'email',
@@ -75,6 +85,7 @@ YAML;
                     'description' => 'Email of the user',
                     'format' => 'email',
                     'example' => 'john@example.com',
+                    'required' => true,
                 ],
                 [
                     'name' => 'age',
@@ -82,6 +93,7 @@ YAML;
                     'description' => 'Age of the user',
                     'format' => 'int',
                     'example' => '18',
+                    'required' => true,
                 ],
                 [
                     'name' => 'isCitizen',
@@ -89,6 +101,7 @@ YAML;
                     'description' => 'Is user a citizen',
                     'format' => 'boolean',
                     'example' => 'true',
+                    'required' => true,
                 ],
             ],
         ];
@@ -122,6 +135,11 @@ UserSignedUp:
         description: 'Is user a citizen'
         format: boolean
         example: 'true'
+    required:
+      - name
+      - email
+      - age
+      - isCitizen
 
 YAML;
 

--- a/tests/Unit/Symfony/Controller/JsonSpecificationControllerTest.php
+++ b/tests/Unit/Symfony/Controller/JsonSpecificationControllerTest.php
@@ -79,31 +79,33 @@ class JsonSpecificationControllerTest extends TestCase
               "type": "string",
               "description": "Name of the user",
               "format": "string",
-              "example": "John",
-              "required": true
+              "example": "John"
             },
             "email": {
               "type": "string",
               "description": "Email of the user",
               "format": "email",
-              "example": "john@example.com",
-               "required": true
+              "example": "john@example.com"
             },
             "age": {
               "type": "integer",
               "description": "Age of the user",
               "format": "int32",
-              "example": "18",
-              "required": true
+              "example": "18"
             },
             "isCitizen": {
               "type": "boolean",
               "description": "Is user a citizen",
               "format": "boolean",
-              "example": "true",
-              "required": true
+              "example": "true"
             }
-          }
+          },
+            "required": [
+                "name",
+                "email",
+                "age",
+                "isCitizen"
+            ]
         }
       },
       "PaymentExecuted": {
@@ -114,17 +116,19 @@ class JsonSpecificationControllerTest extends TestCase
               "type": "number",
               "description": "Payment amount",
               "format": "float",
-              "example": "1000",
-              "required": true
+              "example": "1000"
             },
             "createdAt": {
               "type": "string",
               "description": "Creation date",
               "format": "date-time",
-              "example": "2023-11-23 13:41:21",
-              "required": true
+              "example": "2023-11-23 13:41:21"
             }
-          }
+          },
+            "required": [
+                "amount",
+                "createdAt"
+            ]
         }
       },
       "ProductCreated": {
@@ -133,51 +137,53 @@ class JsonSpecificationControllerTest extends TestCase
           "properties": {
             "id": {
               "type": "integer",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "amount": {
               "type": "number",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "currency": {
               "type": "string",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "isPaid": {
               "type": "boolean",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "createdAt": {
               "type": "string",
               "description": "",
-              "format": "date-time",
-              "required": true
+              "format": "date-time"
             },
             "week": {
               "type": "integer",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "payment": {
               "type": "string",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "products": {
               "type": "string",
-              "description": "",
-              "required": true
+              "description": ""
             },
             "tags": {
               "type": "string",
-              "description": "",
-              "required": true
+              "description": ""
             }
-          }
+          },
+            "required": [
+                "id",
+                "amount",
+                "currency",
+                "isPaid",
+                "createdAt",
+                "week",
+                "payment",
+                "products",
+                "tags"
+            ]
         }
       }
     }

--- a/tests/Unit/Symfony/Controller/JsonSpecificationControllerTest.php
+++ b/tests/Unit/Symfony/Controller/JsonSpecificationControllerTest.php
@@ -79,25 +79,29 @@ class JsonSpecificationControllerTest extends TestCase
               "type": "string",
               "description": "Name of the user",
               "format": "string",
-              "example": "John"
+              "example": "John",
+              "required": true
             },
             "email": {
               "type": "string",
               "description": "Email of the user",
               "format": "email",
-              "example": "john@example.com"
+              "example": "john@example.com",
+               "required": true
             },
             "age": {
               "type": "integer",
               "description": "Age of the user",
               "format": "int32",
-              "example": "18"
+              "example": "18",
+              "required": true
             },
             "isCitizen": {
               "type": "boolean",
               "description": "Is user a citizen",
               "format": "boolean",
-              "example": "true"
+              "example": "true",
+              "required": true
             }
           }
         }
@@ -110,13 +114,15 @@ class JsonSpecificationControllerTest extends TestCase
               "type": "number",
               "description": "Payment amount",
               "format": "float",
-              "example": "1000"
+              "example": "1000",
+              "required": true
             },
             "createdAt": {
               "type": "string",
               "description": "Creation date",
               "format": "date-time",
-              "example": "2023-11-23 13:41:21"
+              "example": "2023-11-23 13:41:21",
+              "required": true
             }
           }
         }
@@ -127,40 +133,49 @@ class JsonSpecificationControllerTest extends TestCase
           "properties": {
             "id": {
               "type": "integer",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "amount": {
               "type": "number",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "currency": {
               "type": "string",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "isPaid": {
               "type": "boolean",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "createdAt": {
               "type": "string",
               "description": "",
-              "format": "date-time"
+              "format": "date-time",
+              "required": true
             },
             "week": {
               "type": "integer",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "payment": {
               "type": "string",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "products": {
               "type": "string",
-              "description": ""
+              "description": "",
+              "required": true
             },
             "tags": {
               "type": "string",
-              "description": ""
+              "description": "",
+              "required": true
             }
           }
         }

--- a/tests/Unit/Symfony/Controller/JsonSpecificationControllerTest.php
+++ b/tests/Unit/Symfony/Controller/JsonSpecificationControllerTest.php
@@ -45,7 +45,7 @@ class JsonSpecificationControllerTest extends TestCase
     "version": "1.2.3",
     "description": "This service is in charge of processing user signups"
   },
-  "servers": {},
+  "servers": [],
   "channels": {
     "user_signed_up": {
       "subscribe": {

--- a/tests/Unit/Symfony/Controller/YamlSpecificationControllerTest.php
+++ b/tests/Unit/Symfony/Controller/YamlSpecificationControllerTest.php
@@ -68,25 +68,26 @@ components:
             description: 'Name of the user'
             format: string
             example: John
-            required: true
           email:
             type: string
             description: 'Email of the user'
             format: email
             example: john@example.com
-            required: true
           age:
             type: integer
             description: 'Age of the user'
             format: int32
             example: '18'
-            required: true
           isCitizen:
             type: boolean
             description: 'Is user a citizen'
             format: boolean
             example: 'true'
-            required: true
+        required:
+          - name
+          - email
+          - age
+          - isCitizen
     PaymentExecuted:
       payload:
         type: object
@@ -96,13 +97,14 @@ components:
             description: 'Payment amount'
             format: float
             example: '1000'
-            required: true
           createdAt:
             type: string
             description: 'Creation date'
             format: date-time
             example: '2023-11-23 13:41:21'
-            required: true
+        required:
+          - amount
+          - createdAt
     ProductCreated:
       payload:
         type: object
@@ -110,40 +112,41 @@ components:
           id:
             type: integer
             description: ''
-            required: true
           amount:
             type: number
             description: ''
-            required: true
           currency:
             type: string
             description: ''
-            required: true
           isPaid:
             type: boolean
             description: ''
-            required: true
           createdAt:
             type: string
             description: ''
             format: date-time
-            required: true
           week:
             type: integer
             description: ''
-            required: true
           payment:
             type: string
             description: ''
-            required: true
           products:
             type: string
             description: ''
-            required: true
           tags:
             type: string
             description: ''
-            required: true
+        required:
+          - id
+          - amount
+          - currency
+          - isPaid
+          - createdAt
+          - week
+          - payment
+          - products
+          - tags
 
 YAML;
 

--- a/tests/Unit/Symfony/Controller/YamlSpecificationControllerTest.php
+++ b/tests/Unit/Symfony/Controller/YamlSpecificationControllerTest.php
@@ -68,21 +68,25 @@ components:
             description: 'Name of the user'
             format: string
             example: John
+            required: true
           email:
             type: string
             description: 'Email of the user'
             format: email
             example: john@example.com
+            required: true
           age:
             type: integer
             description: 'Age of the user'
             format: int32
             example: '18'
+            required: true
           isCitizen:
             type: boolean
             description: 'Is user a citizen'
             format: boolean
             example: 'true'
+            required: true
     PaymentExecuted:
       payload:
         type: object
@@ -92,11 +96,13 @@ components:
             description: 'Payment amount'
             format: float
             example: '1000'
+            required: true
           createdAt:
             type: string
             description: 'Creation date'
             format: date-time
             example: '2023-11-23 13:41:21'
+            required: true
     ProductCreated:
       payload:
         type: object
@@ -104,31 +110,40 @@ components:
           id:
             type: integer
             description: ''
+            required: true
           amount:
             type: number
             description: ''
+            required: true
           currency:
             type: string
             description: ''
+            required: true
           isPaid:
             type: boolean
             description: ''
+            required: true
           createdAt:
             type: string
             description: ''
             format: date-time
+            required: true
           week:
             type: integer
             description: ''
+            required: true
           payment:
             type: string
             description: ''
+            required: true
           products:
             type: string
             description: ''
+            required: true
           tags:
             type: string
             description: ''
+            required: true
 
 YAML;
 


### PR DESCRIPTION
The `Required` option does not seem to be rendering for a property. I am not sure if this is intentional or not. This PR adds the support for it to be rendered out with `required` being defaulted to true. This allows `required` properties to be marked as such. 