### PR TITLE
chore: enable contract between documentation strategy

### DIFF
--- a/src/Attribute/Message.php
+++ b/src/Attribute/Message.php
@@ -16,7 +16,7 @@ class Message implements PropertyInterface
     public function __construct(
         public readonly string $name,
         public readonly string $channel,
-        public readonly array $properties = [],
+        public array $properties = [],
         public readonly ChannelType $channelType = ChannelType::SUBSCRIBE,
     ) {
     }
@@ -29,5 +29,10 @@ class Message implements PropertyInterface
             'properties' => array_map(static fn(PropertyInterface $property) => $property->toArray(), $this->properties),
             'channelType' => $this->channelType->value,
         ];
+    }
+
+    public function addProperty(PropertyInterface $property): void
+    {
+        $this->properties[] = $property;
     }
 }

--- a/src/DocumentationEditor.php
+++ b/src/DocumentationEditor.php
@@ -26,7 +26,7 @@ final readonly class DocumentationEditor
         }
 
         foreach ($strategies as $documentationStrategy) {
-            $result = array_merge($result, $documentationStrategy->document($class));
+            $result = array_merge($result, $documentationStrategy->document($class)->toArray());
         }
 
         return $result;

--- a/src/DocumentationStrategy/AttributeDocumentationStrategy.php
+++ b/src/DocumentationStrategy/AttributeDocumentationStrategy.php
@@ -15,7 +15,7 @@ final readonly class AttributeDocumentationStrategy implements DocumentationStra
     ) {
     }
 
-    public function document(string $class): array
+    public function document(string $class): Message
     {
         $reflection = new ReflectionClass($class);
         /** @var ReflectionAttribute<Message>[] $messageAttributes */
@@ -25,10 +25,10 @@ final readonly class AttributeDocumentationStrategy implements DocumentationStra
             throw new DocumentationStrategyException('Error: class ' . $class . ' must have at least ' . Message::class . ' attribute.');
         }
 
-        $message = $messageAttributes[0]->newInstance()->toArray();
+        $message = $messageAttributes[0]->newInstance();
 
         foreach ($this->propertyExtractor->extract($class) as $property) {
-            $message['properties'][] = $property->toArray();
+            $message->addProperty($property);
         }
 
         return $message;

--- a/src/DocumentationStrategy/DocumentationStrategyInterface.php
+++ b/src/DocumentationStrategy/DocumentationStrategyInterface.php
@@ -4,10 +4,12 @@ declare(strict_types=1);
 
 namespace Ferror\AsyncapiDocBundle\DocumentationStrategy;
 
+use Ferror\AsyncapiDocBundle\Attribute\Message;
+
 interface DocumentationStrategyInterface
 {
     /**
      * @param class-string $class
      */
-    public function document(string $class): array;
+    public function document(string $class): Message;
 }

--- a/src/DocumentationStrategy/ReflectionDocumentationStrategy.php
+++ b/src/DocumentationStrategy/ReflectionDocumentationStrategy.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Ferror\AsyncapiDocBundle\DocumentationStrategy;
 
+use Ferror\AsyncapiDocBundle\Attribute\Message;
+use Ferror\AsyncapiDocBundle\Attribute\Property;
+use Ferror\AsyncapiDocBundle\Schema\PropertyType;
+use ReflectionAttribute;
 use ReflectionClass;
 use ReflectionException;
 use ReflectionNamedType;
@@ -14,27 +18,33 @@ final readonly class ReflectionDocumentationStrategy implements DocumentationStr
      * @param class-string $class
      *
      * @throws ReflectionException
+     * @throws DocumentationStrategyException
      */
-    public function document(string $class): array
+    public function document(string $class): Message
     {
         $reflection = new ReflectionClass($class);
+        /** @var ReflectionAttribute<Message>[] $messageAttributes */
+        $messageAttributes = $reflection->getAttributes(Message::class);
+
+        if (empty($messageAttributes)) {
+            throw new DocumentationStrategyException('Error: class ' . $class . ' must have at least ' . Message::class . ' attribute.');
+        }
+
+        $message = $messageAttributes[0]->newInstance();
+
         $properties = $reflection->getProperties();
-
-        $message['name'] = $reflection->getShortName();
-
         foreach ($properties as $property) {
             /** @var ReflectionNamedType|null $type */
             $type = $property->getType();
             $name = $property->getName();
 
-            if ($type && !$type->allowsNull()) {
-                $message['required'][] = $name;
-            }
-
-            $message['properties'][] = [
-                'name' => $name,
-                'type' => $type?->getName(),
-            ];
+            $message->addProperty(
+                new Property(
+                    name: $name,
+                    type: PropertyType::fromNative($type?->getName()),
+                    required: $type && !$type->allowsNull(),
+                )
+            );
         }
 
         return $message;

--- a/src/Schema/PropertyType.php
+++ b/src/Schema/PropertyType.php
@@ -13,4 +13,14 @@ enum PropertyType: string
     case BOOLEAN = 'boolean';
     case INTEGER = 'integer';
     case FLOAT = 'number';
+
+    public static function fromNative(string $type): self
+    {
+        return match ($type) {
+            'bool', 'boolean' => self::BOOLEAN,
+            'int', 'integer' => self::INTEGER,
+            'float', 'number' => self::FLOAT,
+            default => self::STRING,
+        };
+    }
 }

--- a/src/Schema/V2/SchemaRenderer.php
+++ b/src/Schema/V2/SchemaRenderer.php
@@ -30,6 +30,7 @@ final readonly class SchemaRenderer implements SchemaRendererInterface
 
         foreach ($classes as $class) {
             $document = $this->documentationStrategy->document($class);
+            $document = $document->toArray();
             $channel = $this->channelRenderer->render($document);
             $message = $this->messageRenderer->render($document);
 

--- a/src/Symfony/Console/DumpSpecificationConsole.php
+++ b/src/Symfony/Console/DumpSpecificationConsole.php
@@ -36,7 +36,7 @@ class DumpSpecificationConsole extends Command
         if ($input->getArgument('class')) {
             $document = $this->documentationStrategy->document($input->getArgument('class'));
 
-            $schema = $this->messageRenderer->render($document);
+            $schema = $this->messageRenderer->render($document->toArray());
 
             $io->writeln(Yaml::dump($schema, 10, 2));
 

--- a/tests/Unit/DocumentationStrategy/AttributeDocumentationStrategyTest.php
+++ b/tests/Unit/DocumentationStrategy/AttributeDocumentationStrategyTest.php
@@ -16,6 +16,8 @@ class AttributeDocumentationStrategyTest extends TestCase
     {
         $documentation = new AttributeDocumentationStrategy(new PropertyExtractor());
 
+        $actual = $documentation->document(UserSignedUp::class)->toArray();
+
         $expected = [
             'name' => 'UserSignedUp',
             'channel' => 'user_signed_up',
@@ -56,12 +58,14 @@ class AttributeDocumentationStrategyTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $documentation->document(UserSignedUp::class));
+        $this->assertEquals($expected, $actual);
     }
 
     public function testProductCreated(): void
     {
         $documentation = new AttributeDocumentationStrategy(new PropertyExtractor());
+
+        $actual = $documentation->document(ProductCreated::class)->toArray();
 
         $expected = [
             'name' => 'ProductCreated',
@@ -144,6 +148,6 @@ class AttributeDocumentationStrategyTest extends TestCase
             ],
         ];
 
-        $this->assertEquals($expected, $documentation->document(ProductCreated::class));
+        $this->assertEquals($expected, $actual);
     }
 }

--- a/tests/Unit/DocumentationStrategy/ReflectionDocumentationStrategyTest.php
+++ b/tests/Unit/DocumentationStrategy/ReflectionDocumentationStrategyTest.php
@@ -16,32 +16,44 @@ class ReflectionDocumentationStrategyTest extends TestCase
 
         $expected = [
             'name' => 'UserSignedUp',
+            'channel' => 'user_signed_up',
+            'channelType' => 'subscribe',
             'properties' => [
                 [
                     'name' => 'name',
                     'type' => 'string',
+                    'required' => true,
+                    'description' => '',
+                    'format' => null,
+                    'example' => null,
                 ],
                 [
                     'name' => 'email',
                     'type' => 'string',
+                    'required' => true,
+                    'description' => '',
+                    'format' => null,
+                    'example' => null,
                 ],
                 [
                     'name' => 'age',
-                    'type' => 'int',
+                    'type' => 'integer',
+                    'required' => true,
+                    'description' => '',
+                    'format' => null,
+                    'example' => null,
                 ],
                 [
                     'name' => 'isCitizen',
-                    'type' => 'bool',
+                    'type' => 'boolean',
+                    'required' => true,
+                    'description' => '',
+                    'format' => null,
+                    'example' => null,
                 ],
             ],
-            'required' => [
-                'name',
-                'email',
-                'age',
-                'isCitizen',
-            ]
         ];
 
-        $this->assertEquals($expected, $documentation->document(UserSignedUp::class));
+        $this->assertEquals($expected, $documentation->document(UserSignedUp::class)->toArray());
     }
 }


### PR DESCRIPTION
Quite a smart-ish improvement when instead of an array as contract (a bad one, but flexible), we can reuse the Message and Property attributes, so now instead of array-ing properties, we just add extra property either via Reflection or via an attribute.