### PR TITLE
feat: channel attribute extraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,8 +55,10 @@ ferror_asyncapi_doc_bundle_html:
 
 ```php
 use Ferror\AsyncapiDocBundle\Attribute\Message;
+use Ferror\AsyncapiDocBundle\Attribute\Channel;
 
-#[Message(name: 'ProductCreated', channel: 'product.created')]
+#[Message(name: 'ProductCreated')]
+#[Channel(name: 'product.created')] // optional
 final readonly class ProductCreated
 {
     public function __construct(
@@ -81,7 +83,8 @@ use Ferror\AsyncapiDocBundle\Attribute as AA;
 use Ferror\AsyncapiDocBundle\Schema\Format;
 use Ferror\AsyncapiDocBundle\Schema\PropertyType;
 
-#[AA\Message(name: 'ProductCreated', channel: 'product.created')]
+#[AA\Message(name: 'ProductCreated')]
+#[AA\Channel(name: 'product.created')] // optional
 final readonly class ProductCreated
 {
     public function __construct(

--- a/example/src/ProductCreated.php
+++ b/example/src/ProductCreated.php
@@ -5,13 +5,15 @@ declare(strict_types=1);
 namespace App;
 
 use DateTime;
+use Ferror\AsyncapiDocBundle\Attribute\Channel;
 use Ferror\AsyncapiDocBundle\Attribute\Message;
 use Ferror\AsyncapiDocBundle\Attribute\Property;
 use Ferror\AsyncapiDocBundle\Attribute\PropertyArray;
 use Ferror\AsyncapiDocBundle\Schema\Format;
 use Ferror\AsyncapiDocBundle\Schema\PropertyType;
 
-#[Message(name: 'ProductCreated', channel: 'product.created')]
+#[Message(name: 'ProductCreated')]
+#[Channel(name: 'product.created')]
 final readonly class ProductCreated
 {
     /**

--- a/example/src/UserSignedUp.php
+++ b/example/src/UserSignedUp.php
@@ -4,9 +4,11 @@ declare(strict_types=1);
 
 namespace App;
 
+use Ferror\AsyncapiDocBundle\Attribute\Channel;
 use Ferror\AsyncapiDocBundle\Attribute\Message;
 
-#[Message(name: 'UserSignedUp', channel: 'user_signed_up')]
+#[Message(name: 'UserSignedUp')]
+#[Channel(name: 'user_signed_up')]
 final readonly class UserSignedUp
 {
     public function __construct(

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -16,6 +16,9 @@
         <testsuite name="all">
             <directory>tests</directory>
         </testsuite>
+        <testsuite name="unit">
+            <directory>tests/Unit</directory>
+        </testsuite>
     </testsuites>
 
     <php>

--- a/src/Attribute/Channel.php
+++ b/src/Attribute/Channel.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ferror\AsyncapiDocBundle\Attribute;
+
+use Attribute;
+use Ferror\AsyncapiDocBundle\Schema\V2\ChannelType;
+
+#[Attribute(Attribute::TARGET_CLASS)]
+readonly class Channel
+{
+    public function __construct(
+        public string $name,
+        public ChannelType $type = ChannelType::SUBSCRIBE,
+    ) {
+    }
+
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'type' => $this->type->value,
+        ];
+    }
+}

--- a/src/Attribute/Message.php
+++ b/src/Attribute/Message.php
@@ -5,19 +5,18 @@ declare(strict_types=1);
 namespace Ferror\AsyncapiDocBundle\Attribute;
 
 use Attribute;
-use Ferror\AsyncapiDocBundle\Schema\V2\ChannelType;
 
 #[Attribute(Attribute::TARGET_CLASS)]
 class Message
 {
     /**
      * @param array<Property|PropertyArray|PropertyEnum|PropertyObject|PropertyArrayObject> $properties
+     * @param Channel[] $channels
      */
     public function __construct(
         public readonly string $name,
-        public readonly string $channel,
         public array $properties = [],
-        public readonly ChannelType $channelType = ChannelType::SUBSCRIBE,
+        public array $channels = [],
     ) {
     }
 
@@ -25,15 +24,19 @@ class Message
     {
         return [
             'name' => $this->name,
-            'channel' => $this->channel,
             'properties' => array_map(static fn(PropertyInterface $property) => $property->toArray(), $this->properties),
-            'channelType' => $this->channelType->value,
+            'channels' => array_map(static fn(Channel $channel) => $channel->toArray(), $this->channels),
         ];
     }
 
     public function addProperty(Property|PropertyArray|PropertyEnum|PropertyObject|PropertyArrayObject $property): void
     {
         $this->properties[] = $property;
+    }
+
+    public function addChannel(Channel $channel): void
+    {
+        $this->channels[] = $channel;
     }
 
     public function enrich(self $self): self

--- a/src/DocumentationStrategy/AttributeDocumentationStrategy.php
+++ b/src/DocumentationStrategy/AttributeDocumentationStrategy.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ferror\AsyncapiDocBundle\DocumentationStrategy;
 
+use Ferror\AsyncapiDocBundle\Attribute\Channel;
 use Ferror\AsyncapiDocBundle\Attribute\Message;
 use ReflectionAttribute;
 use ReflectionClass;
@@ -39,6 +40,14 @@ final readonly class AttributeDocumentationStrategy implements PrioritisedDocume
 
         foreach ($this->propertyExtractor->extract($class) as $property) {
             $message->addProperty($property);
+        }
+
+        // Channels are optional as it's possible to document just Messages.
+        /** @var ReflectionAttribute<Channel>[] $messageAttributes */
+        $channelAttributes = $reflection->getAttributes(Channel::class);
+
+        foreach ($channelAttributes as $channelAttribute) {
+            $message->addChannel($channelAttribute->newInstance());
         }
 
         return $message;

--- a/src/Schema/V2/ChannelRenderer.php
+++ b/src/Schema/V2/ChannelRenderer.php
@@ -8,14 +8,18 @@ class ChannelRenderer
 {
     public function render(array $document): array
     {
-        $channel[$document['channel']] = [
-            $document['channelType'] => [
-                'message' => [
-                    '$ref' => '#/components/messages/' . $document['name'],
-                ],
-            ],
-        ];
+        $channels = [];
 
-        return $channel;
+        foreach ($document['channels'] as $channel) {
+            $channels[$channel['name']] = [
+                $channel['type'] => [
+                    'message' => [
+                        '$ref' => '#/components/messages/' . $document['name'],
+                    ],
+                ],
+            ];
+        }
+
+        return $channels;
     }
 }

--- a/tests/Examples/PaymentExecuted.php
+++ b/tests/Examples/PaymentExecuted.php
@@ -4,12 +4,14 @@ declare(strict_types=1);
 
 namespace Ferror\AsyncapiDocBundle\Tests\Examples;
 
+use Ferror\AsyncapiDocBundle\Attribute\Channel;
 use Ferror\AsyncapiDocBundle\Attribute\Message;
 
 /**
  * This class represents an example of documenting by ReflectionStrategy
  */
-#[Message(name: 'PaymentExecuted', channel: 'payment_executed')]
+#[Message(name: 'PaymentExecuted')]
+#[Channel(name: 'payment_executed')]
 final readonly class PaymentExecuted
 {
     public function __construct(

--- a/tests/Examples/ProductCreated.php
+++ b/tests/Examples/ProductCreated.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ferror\AsyncapiDocBundle\Tests\Examples;
 
 use DateTime;
+use Ferror\AsyncapiDocBundle\Attribute\Channel;
 use Ferror\AsyncapiDocBundle\Attribute\Message;
 use Ferror\AsyncapiDocBundle\Attribute\Property;
 use Ferror\AsyncapiDocBundle\Attribute\PropertyArray;
@@ -17,7 +18,8 @@ use Ferror\AsyncapiDocBundle\Schema\PropertyType;
 /**
  * This class represents an example of documenting by AttributeStrategy. It contains all types.
  */
-#[Message(name: 'ProductCreated', channel: 'product.created')]
+#[Message(name: 'ProductCreated')]
+#[Channel(name: 'product.created')]
 final readonly class ProductCreated
 {
     /**

--- a/tests/Examples/ProductUpdated.php
+++ b/tests/Examples/ProductUpdated.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Ferror\AsyncapiDocBundle\Tests\Examples;
 
 use DateTime;
+use Ferror\AsyncapiDocBundle\Attribute\Channel;
 use Ferror\AsyncapiDocBundle\Attribute\Message;
 use Ferror\AsyncapiDocBundle\Attribute\Property;
 use Ferror\AsyncapiDocBundle\Attribute\PropertyArray;
@@ -19,7 +20,6 @@ use Ferror\AsyncapiDocBundle\Schema\PropertyType;
  */
 #[Message(
     name: 'ProductUpdated',
-    channel: 'product.updated',
     properties: [
         new Property(name: 'id', type: PropertyType::INTEGER),
         new Property(name: 'amount', type: PropertyType::FLOAT),
@@ -32,6 +32,7 @@ use Ferror\AsyncapiDocBundle\Schema\PropertyType;
         new PropertyArray(name: 'tags', itemsType: PropertyType::STRING),
     ],
 )]
+#[Channel(name: 'product.updated')]
 final readonly class ProductUpdated
 {
     /**

--- a/tests/Examples/UserSignedUp.php
+++ b/tests/Examples/UserSignedUp.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Ferror\AsyncapiDocBundle\Tests\Examples;
 
+use Ferror\AsyncapiDocBundle\Attribute\Channel;
 use Ferror\AsyncapiDocBundle\Attribute\Message;
 use Ferror\AsyncapiDocBundle\Attribute\Property;
 use Ferror\AsyncapiDocBundle\Schema\Format;
@@ -12,7 +13,8 @@ use Ferror\AsyncapiDocBundle\Schema\PropertyType;
 /**
  * This class represents a SIMPLE example of documenting by AttributeStrategy.
  */
-#[Message(name: 'UserSignedUp', channel: 'user_signed_up')]
+#[Message(name: 'UserSignedUp')]
+#[Channel(name: 'user_signed_up')]
 final readonly class UserSignedUp
 {
     public function __construct(

--- a/tests/Unit/Attribute/MessageTest.php
+++ b/tests/Unit/Attribute/MessageTest.php
@@ -12,18 +12,18 @@ final class MessageTest extends TestCase
 {
     public function testEnrichAddsProperty(): void
     {
-        $message = new Message('name', 'channel');
+        $message = new Message('name');
 
-        $message->enrich(new Message('name', 'channel', [new Property('name')]));
+        $message->enrich(new Message('name', [new Property('name')]));
 
         $this->assertCount(1, $message->properties);
     }
 
     public function testEnrichUpdatesProperty(): void
     {
-        $message = new Message('name', 'channel', [new Property('name')]);
+        $message = new Message('name', [new Property('name')]);
 
-        $message->enrich(new Message('name', 'channel', [new Property('name', 'Nice Description')]));
+        $message->enrich(new Message('name', [new Property('name', 'Nice Description')]));
 
         $this->assertEquals('Nice Description', $message->properties[0]->description);
     }

--- a/tests/Unit/DocumentationEditorTest.php
+++ b/tests/Unit/DocumentationEditorTest.php
@@ -24,8 +24,6 @@ final class DocumentationEditorTest extends TestCase
 
         $expected = [
             'name' => 'PaymentExecuted',
-            'channel' => 'payment_executed',
-            'channelType' => 'subscribe',
             'properties' => [
                 [
                     'name' => 'amount',
@@ -44,6 +42,7 @@ final class DocumentationEditorTest extends TestCase
                     'example' => null,
                 ],
             ],
+            'channels' => [],
         ];
 
         $this->assertEquals($expected, $actual);

--- a/tests/Unit/DocumentationStrategy/AttributeDocumentationStrategyTest.php
+++ b/tests/Unit/DocumentationStrategy/AttributeDocumentationStrategyTest.php
@@ -20,8 +20,6 @@ class AttributeDocumentationStrategyTest extends TestCase
 
         $expected = [
             'name' => 'UserSignedUp',
-            'channel' => 'user_signed_up',
-            'channelType' => 'subscribe',
             'properties' => [
                 [
                     'name' => 'name',
@@ -56,6 +54,12 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'required' => true,
                 ],
             ],
+            'channels' => [
+                [
+                    'name' => 'user_signed_up',
+                    'type' => 'subscribe',
+                ],
+            ],
         ];
 
         $this->assertEquals($expected, $actual);
@@ -69,8 +73,6 @@ class AttributeDocumentationStrategyTest extends TestCase
 
         $expected = [
             'name' => 'ProductCreated',
-            'channel' => 'product.created',
-            'channelType' => 'subscribe',
             'properties' => [
                 [
                     'name' => 'id',
@@ -144,6 +146,12 @@ class AttributeDocumentationStrategyTest extends TestCase
                     'example' => null,
                     'itemsType' => 'string',
                     'required' => true,
+                ],
+            ],
+            'channels' => [
+                [
+                    'name' => 'product.created',
+                    'type' => 'subscribe',
                 ],
             ],
         ];

--- a/tests/Unit/DocumentationStrategy/ReflectionDocumentationStrategyTest.php
+++ b/tests/Unit/DocumentationStrategy/ReflectionDocumentationStrategyTest.php
@@ -17,8 +17,6 @@ class ReflectionDocumentationStrategyTest extends TestCase
 
         $expected = [
             'name' => 'UserSignedUp',
-            'channel' => 'user_signed_up',
-            'channelType' => 'subscribe',
             'properties' => [
                 [
                     'name' => 'name',
@@ -53,6 +51,7 @@ class ReflectionDocumentationStrategyTest extends TestCase
                     'example' => null,
                 ],
             ],
+            'channels' => [],
         ];
 
         $this->assertEquals($expected, $documentation->document(UserSignedUp::class)->toArray());
@@ -64,8 +63,6 @@ class ReflectionDocumentationStrategyTest extends TestCase
 
         $expected = [
             'name' => 'ProductCreated',
-            'channel' => 'product.created',
-            'channelType' => 'subscribe',
             'properties' => [
                 [
                     'name' => 'id',
@@ -100,6 +97,7 @@ class ReflectionDocumentationStrategyTest extends TestCase
                     'example' => null
                 ],
             ],
+            'channels' => [],
         ];
 
 

--- a/tests/Unit/Schema/V2/ChannelRendererTest.php
+++ b/tests/Unit/Schema/V2/ChannelRendererTest.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Ferror\AsyncapiDocBundle\Tests\Unit\Schema\V2;
+
+use Ferror\AsyncapiDocBundle\Schema\V2\ChannelRenderer;
+use PHPUnit\Framework\TestCase;
+
+class ChannelRendererTest extends TestCase
+{
+    public function testSingleChannel(): void
+    {
+        $document = [
+            'name' => 'UserSignedUp',
+            'channels' => [
+                [
+                    'name' => 'UserSignedUpChannel',
+                    'type' => 'subscribe',
+                ]
+            ]
+        ];
+
+        $schema = new ChannelRenderer();
+
+        $actual = $schema->render($document);
+
+        $expected = [
+            'UserSignedUpChannel' => [
+                'subscribe' => [
+                    'message' => [
+                        '$ref' => '#/components/messages/UserSignedUp',
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertEquals($expected, $actual);
+    }
+}

--- a/tests/Unit/Schema/V2/MessageRendererTest.php
+++ b/tests/Unit/Schema/V2/MessageRendererTest.php
@@ -6,7 +6,6 @@ namespace Ferror\AsyncapiDocBundle\Tests\Unit\Schema\V2;
 
 use Ferror\AsyncapiDocBundle\Schema\V2\MessageRenderer;
 use PHPUnit\Framework\TestCase;
-use Symfony\Component\Yaml\Yaml;
 
 class MessageRendererTest extends TestCase
 {
@@ -40,30 +39,29 @@ class MessageRendererTest extends TestCase
 
         $schema = new MessageRenderer();
 
-        $specification = $schema->render($document);
+        $actual = $schema->render($document);
 
-        $expectedSpecification = <<<YAML
-UserSignedUp:
-  payload:
-    type: object
-    properties:
-      name:
-        type: string
-      email:
-        type: string
-      age:
-        type: integer
-      isCitizen:
-        type: boolean
-    required:
-      - name
-      - email
-      - age
-      - isCitizen
+        $expected = [
+            'UserSignedUp' => [
+                'payload' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => ['type' => 'string'],
+                        'email' => ['type' => 'string'],
+                        'age' => ['type' => 'integer'],
+                        'isCitizen' => ['type' => 'boolean'],
+                    ],
+                    'required' => [
+                        'name',
+                        'email',
+                        'age',
+                        'isCitizen',
+                    ],
+                ],
+            ],
+        ];
 
-YAML;
-
-        $this->assertEquals($expectedSpecification, Yaml::dump($specification, 10, 2));
+        $this->assertEquals($expected, $actual);
     }
 
     public function testAttributes(): void
@@ -108,42 +106,49 @@ YAML;
 
         $schema = new MessageRenderer();
 
-        $specification = $schema->render($document);
+        $actual = $schema->render($document);
 
-        $expectedSpecification = <<<YAML
-UserSignedUp:
-  payload:
-    type: object
-    properties:
-      name:
-        type: string
-        description: 'Name of the user'
-        format: string
-        example: John
-      email:
-        type: string
-        description: 'Email of the user'
-        format: email
-        example: john@example.com
-      age:
-        type: integer
-        description: 'Age of the user'
-        format: int
-        example: '18'
-      isCitizen:
-        type: boolean
-        description: 'Is user a citizen'
-        format: boolean
-        example: 'true'
-    required:
-      - name
-      - email
-      - age
-      - isCitizen
+        $expected = [
+            'UserSignedUp' => [
+                'payload' => [
+                    'type' => 'object',
+                    'properties' => [
+                        'name' => [
+                            'type' => 'string',
+                            'description' => 'Name of the user',
+                            'format' => 'string',
+                            'example' => 'John',
+                        ],
+                        'email' => [
+                            'type' => 'string',
+                            'description' => 'Email of the user',
+                            'format' => 'email',
+                            'example' => 'john@example.com',
+                        ],
+                        'age' => [
+                            'type' => 'integer',
+                            'description' => 'Age of the user',
+                            'format' => 'int',
+                            'example' => '18',
+                        ],
+                        'isCitizen' => [
+                            'type' => 'boolean',
+                            'description' => 'Is user a citizen',
+                            'format' => 'boolean',
+                            'example' => 'true',
+                        ],
+                    ],
+                    'required' => [
+                        'name',
+                        'email',
+                        'age',
+                        'isCitizen',
+                    ],
+                ],
+            ],
+        ];
 
-YAML;
-
-        $this->assertEquals($expectedSpecification, Yaml::dump($specification, 10, 2));
+        $this->assertEquals($expected, $actual);
     }
 
     public function testDoesNotRenderEmptyData(): void


### PR DESCRIPTION
Part of migration to Schema V3. The channel should be extracted from message as there may be many channels for one message and in V3 version the new operation attribute is coming.